### PR TITLE
Peer download worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "urlencoding",
 ]
 
@@ -681,6 +683,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +760,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1135,6 +1153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1265,16 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1349,7 +1386,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1359,6 +1408,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1419,6 +1494,12 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -1516,6 +1597,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ static_str_ops = "0.1.2"
 tokio = { version = "1.35.1", features = ["full"] }
 tokio-stream = "0.1.15"
 tokio-util = { version = "0.7.11", features = ["codec"] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 urlencoding = "2.1.3"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod metainfo;
 mod peer_protocol;
+mod peers;
 mod prelude;
 mod torrent;
 mod tracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod metainfo;
 mod peer_protocol;
+mod prelude;
 mod torrent;
 mod tracker;
 
@@ -23,10 +24,19 @@ use tracker::{
     Announce, HttpTracker,
 };
 
+use prelude::*;
+use tracing::Level;
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .pretty()
+        .with_target(false)
+        .init();
     let matches = Cli::parse();
     let metainfo = metainfo::Metainfo::from_bencode_file(matches.source)?;
+
     let peer_id = PeerId::random();
     let request = TrackerRequest::new(peer_id.clone(), matches.port, &metainfo.file_info)?;
 

--- a/src/metainfo/mod.rs
+++ b/src/metainfo/mod.rs
@@ -2,7 +2,6 @@ pub mod files;
 pub mod tracker_url;
 
 use serde::Deserialize;
-use serde_bencode;
 use std::fs;
 use std::path::Path;
 

--- a/src/metainfo/tracker_url.rs
+++ b/src/metainfo/tracker_url.rs
@@ -9,8 +9,8 @@ pub struct HttpUrl(Url);
 
 #[derive(Debug, Clone)]
 pub enum TrackerUrl {
-    HTTP(HttpUrl),
-    UDP(UdpUrl),
+    Http(HttpUrl),
+    Udp(UdpUrl),
 }
 
 impl AsRef<str> for HttpUrl {
@@ -53,9 +53,9 @@ impl TrackerUrl {
     fn new(url: impl IntoUrl) -> anyhow::Result<Self> {
         let url = url.into_url()?;
         Ok(match url.scheme() {
-            "http" => Self::HTTP(HttpUrl(url)),
-            "udp" => Self::UDP(UdpUrl(url)),
-            scheme @ _ => anyhow::bail!(format!("unsupported scheme {:?} for tracker", scheme)),
+            "http" => Self::Http(HttpUrl(url)),
+            "udp" => Self::Udp(UdpUrl(url)),
+            scheme => anyhow::bail!(format!("unsupported scheme {:?} for tracker", scheme)),
         })
     }
 }

--- a/src/peer_protocol/codec.rs
+++ b/src/peer_protocol/codec.rs
@@ -1,3 +1,4 @@
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::{
     bytes::{self, Buf, BufMut},
     codec::{Decoder, Encoder},
@@ -58,7 +59,7 @@ impl PeerMessage {
 pub struct PeerMessageCodec;
 
 impl PeerMessageCodec {
-    const MAX_SIZE: usize = 2 * (1 << 10);
+    const MAX_SIZE: usize = 2 * (1 << 20);
 
     // bail if the peer sends invalid(less than what is required) length for the particular variant.
     fn bail_on_size_mismatch(src: &mut bytes::BytesMut, min_size: usize) -> anyhow::Result<()> {
@@ -234,3 +235,10 @@ impl Encoder<PeerMessage> for PeerMessageCodec {
 }
 
 pub type PeerFrames<T> = tokio_util::codec::Framed<T, PeerMessageCodec>;
+
+pub fn upgrade_stream<T>(stream: T) -> PeerFrames<T>
+where
+    T: AsyncRead + AsyncWrite,
+{
+    PeerFrames::new(stream, PeerMessageCodec)
+}

--- a/src/peer_protocol/codec.rs
+++ b/src/peer_protocol/codec.rs
@@ -1,7 +1,7 @@
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::{
     bytes::{self, Buf, BufMut},
-    codec::{Decoder, Encoder},
+    codec::{length_delimited::LengthDelimitedCodec, Decoder, Encoder, Framed},
 };
 
 use crate::torrent::Bitfield;
@@ -56,10 +56,20 @@ impl PeerMessage {
     }
 }
 
-pub struct PeerMessageCodec;
+pub struct PeerMessageCodec {
+    inner_codec: LengthDelimitedCodec,
+}
 
 impl PeerMessageCodec {
-    const MAX_SIZE: usize = 2 * (1 << 20);
+    const MAX_FRAME_SIZE: usize = 2 * (1 << 20);
+
+    pub fn new() -> Self {
+        Self {
+            inner_codec: LengthDelimitedCodec::builder()
+                .max_frame_length(Self::MAX_FRAME_SIZE)
+                .new_codec(),
+        }
+    }
 
     // bail if the peer sends invalid(less than what is required) length for the particular variant.
     fn bail_on_size_mismatch(src: &mut bytes::BytesMut, min_size: usize) -> anyhow::Result<()> {
@@ -87,47 +97,18 @@ impl Decoder for PeerMessageCodec {
     type Error = anyhow::Error;
 
     fn decode(&mut self, src: &mut bytes::BytesMut) -> anyhow::Result<Option<Self::Item>> {
-        const LEN_HEADER_SIZE: usize = std::mem::size_of::<u32>();
-
-        if src.len() < LEN_HEADER_SIZE {
-            // return None to signify that more bytes need to be read for current frame to be
-            // decoded.
-            return Ok(None);
-        }
-
-        let len_header = {
-            // peek at the length and see if enough data has been read. otherwise do not advance
-            // the cursor.
-            let mut len_header: [u8; 4] = [0; 4];
-            len_header.copy_from_slice(&src[0..4]);
-            let len_header = u32::from_be_bytes(len_header) as usize;
-
-            // prevent malicious peers (if they exist) from hogging us.
-            if len_header > Self::MAX_SIZE {
-                anyhow::bail!(
-                    "frames of size {} (>2 MiB) prevented from being decoded.",
-                    len_header
-                )
-            }
-
-            if src.len() < len_header {
-                src.reserve(len_header);
-                return Ok(None);
-            }
-
-            src.advance(LEN_HEADER_SIZE);
-
-            len_header
+        let mut frame = match self.inner_codec.decode(src)? {
+            Some(frame) => frame,
+            None => return Ok(None),
         };
-        // enough data has been read for a full frame, now it is safe to to use get methods.
 
-        if len_header == 0 {
-            // message was a keep alive
+        // message was a keepalive (length = 0)
+        if frame.is_empty() {
             return Ok(None);
         }
-        let mut src = src.split_to(len_header);
 
-        let tag = src.get_u8();
+        let tag = frame.get_u8();
+
         type PM = PeerMessage;
         let msg = match tag {
             PeerMessageTags::CHOKE => PM::Choke,
@@ -135,13 +116,13 @@ impl Decoder for PeerMessageCodec {
             PeerMessageTags::INTERERSTED => PM::Interested,
             PeerMessageTags::NOT_INTERESTED => PM::NotInterested,
             PeerMessageTags::HAVE => {
-                Self::bail_on_size_mismatch(&mut src, std::mem::size_of::<u32>())?;
-                PM::Have(src.get_u32())
+                Self::bail_on_size_mismatch(&mut frame, std::mem::size_of::<u32>())?;
+                PM::Have(frame.get_u32())
             }
             // a panic shouldn't happen here as any amount of bytes is valid
-            PeerMessageTags::BITFIELD => PM::Bitfield(Bitfield::from_vec(src.to_vec())),
+            PeerMessageTags::BITFIELD => PM::Bitfield(Bitfield::from_vec(frame.to_vec())),
             PeerMessageTags::REQUEST => {
-                let (index, begin, length) = Self::decode_triple_variant(&mut src)?;
+                let (index, begin, length) = Self::decode_triple_variant(&mut frame)?;
 
                 PM::Request {
                     index,
@@ -150,16 +131,16 @@ impl Decoder for PeerMessageCodec {
                 }
             }
             PeerMessageTags::PIECE => {
-                Self::bail_on_size_mismatch(&mut src, 2 * std::mem::size_of::<u32>())?;
+                Self::bail_on_size_mismatch(&mut frame, 2 * std::mem::size_of::<u32>())?;
 
                 PM::Piece {
-                    index: src.get_u32(),
-                    begin: src.get_u32(),
-                    piece: src.to_vec(),
+                    index: frame.get_u32(),
+                    begin: frame.get_u32(),
+                    piece: frame.to_vec(),
                 }
             }
             PeerMessageTags::CANCEL => {
-                let (index, begin, length) = Self::decode_triple_variant(&mut src)?;
+                let (index, begin, length) = Self::decode_triple_variant(&mut frame)?;
 
                 PM::Cancel {
                     index,
@@ -234,11 +215,11 @@ impl Encoder<PeerMessage> for PeerMessageCodec {
     }
 }
 
-pub type PeerFrames<T> = tokio_util::codec::Framed<T, PeerMessageCodec>;
+pub type PeerFrames<T> = Framed<T, PeerMessageCodec>;
 
 pub fn upgrade_stream<T>(stream: T) -> PeerFrames<T>
 where
     T: AsyncRead + AsyncWrite,
 {
-    PeerFrames::new(stream, PeerMessageCodec)
+    PeerFrames::new(stream, PeerMessageCodec::new())
 }

--- a/src/peer_protocol/codec.rs
+++ b/src/peer_protocol/codec.rs
@@ -56,6 +56,7 @@ impl PeerMessage {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PeerMessageCodec {
     // codec only used on decode, to decode length delimited frames.
     inner_codec: LengthDelimitedCodec,

--- a/src/peer_protocol/handshake.rs
+++ b/src/peer_protocol/handshake.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use crate::torrent::{InfoHash, PeerId};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -8,8 +9,8 @@ pub struct PeerHandshake {
     protocol_prefix_length: u8,
     protocol_prefix: [u8; 19],
     reserved_bytes: [u8; 8],
-    info_hash: InfoHash,
-    peer_id: PeerId,
+    pub info_hash: InfoHash,
+    pub peer_id: PeerId,
 }
 
 impl PeerHandshake {
@@ -26,7 +27,16 @@ impl PeerHandshake {
 
     // the unsafe is fine becuase the struct is just plain old data, any sequence of bits is valid.
     pub fn from_bytes(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
-        unsafe { std::mem::transmute::<[u8; std::mem::size_of::<Self>()], Self>(bytes) }
+        let handshake =
+            unsafe { std::mem::transmute::<[u8; std::mem::size_of::<Self>()], Self>(bytes) };
+        if handshake.protocol_prefix != Self::PROTOCOL_PREFIX {
+            warn!(
+                "unknown protocol prefix in handshake '{}'",
+                String::from_utf8_lossy(&handshake.protocol_prefix[..])
+            );
+        }
+
+        handshake
     }
     // the unsafe is fine becuase the struct is just plain old data, any sequence of bits is valid.
     pub fn into_bytes(self) -> [u8; std::mem::size_of::<Self>()] {

--- a/src/peers/comms.rs
+++ b/src/peers/comms.rs
@@ -1,0 +1,45 @@
+use super::{PieceIndex, PieceLength};
+use crate::Bitfield;
+use std::net::SocketAddrV4;
+use tokio::sync::mpsc;
+
+use crate::metainfo::files::FileHash;
+
+#[derive(Debug, Clone)]
+pub struct PieceRequestInfo {
+    pub index: PieceIndex,
+    pub length: u32,
+    pub hash: FileHash,
+}
+
+impl PieceRequestInfo {
+    pub fn new(index: PieceIndex, length: PieceLength, hash: FileHash) -> Self {
+        Self {
+            index,
+            length,
+            hash,
+        }
+    }
+}
+
+pub enum PeerCommands {
+    NotInterested,
+    DownloadPiece(PieceRequestInfo),
+    Shutdown,
+}
+
+pub enum PeerAlerts {
+    InitPeer {
+        peer_addr: SocketAddrV4,
+        bitfield: Bitfield,
+        commands_tx: mpsc::Sender<PeerCommands>,
+    },
+    UpdateBitfield {
+        peer_addr: std::net::SocketAddrV4,
+        has_piece: PieceIndex,
+    },
+    DonePiece {
+        piece_index: PieceIndex,
+        piece: Vec<u8>,
+    },
+}

--- a/src/peers/descriptor.rs
+++ b/src/peers/descriptor.rs
@@ -1,0 +1,45 @@
+use crate::peer_protocol::codec::PeerFrames;
+use tokio::sync::mpsc;
+
+use super::{PeerAlerts, PeerCommands};
+use std::collections::VecDeque;
+
+use super::PieceRequestInfo;
+use crate::PeerId;
+use std::net::SocketAddrV4;
+use tokio::net::TcpStream;
+
+#[derive(Debug)]
+/// data struct that owns all the types which describe the state of the worker independent of the
+/// download state.
+pub(super) struct WorkerStateDescriptor {
+    pub peer_addr: SocketAddrV4,
+    pub peer_id: PeerId,
+    pub peer_stream: PeerFrames<TcpStream>,
+    pub commands_rx: mpsc::Receiver<PeerCommands>,
+    pub alerts_tx: mpsc::Sender<PeerAlerts>,
+    pub download_queue: VecDeque<PieceRequestInfo>,
+    pub peer_is_choked: bool,
+    pub we_are_interested: bool,
+}
+
+impl WorkerStateDescriptor {
+    pub fn new(
+        peer_stream: PeerFrames<TcpStream>,
+        peer_addr: SocketAddrV4,
+        peer_id: PeerId,
+        alerts_tx: mpsc::Sender<PeerAlerts>,
+        commands_rx: mpsc::Receiver<PeerCommands>,
+    ) -> Self {
+        Self {
+            peer_stream,
+            peer_addr,
+            peer_id,
+            alerts_tx,
+            commands_rx,
+            peer_is_choked: true,
+            we_are_interested: false,
+            download_queue: VecDeque::new(),
+        }
+    }
+}

--- a/src/peers/download_worker.rs
+++ b/src/peers/download_worker.rs
@@ -1,0 +1,126 @@
+use super::PeerAlerts;
+use futures::StreamExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+
+use crate::prelude::*;
+use crate::torrent::{InfoHash, PeerId};
+use std::net::SocketAddrV4;
+
+use super::descriptor::WorkerStateDescriptor;
+use super::worker_fsm::WorkerState;
+
+use crate::peer_protocol::codec::{self, PeerMessage};
+use crate::peer_protocol::handshake::PeerHandshake;
+
+#[derive(Debug, Clone)]
+pub struct PeerAddr {
+    peer_addr: SocketAddrV4,
+}
+
+/// interface type between PeerAddr and PeerDownloadWorker
+#[derive(Debug)]
+pub struct PeerDownloaderConnection {
+    peer_addr: SocketAddrV4,
+    peer_id: PeerId,
+    stream: TcpStream,
+}
+
+#[derive(Debug)]
+pub struct PeerDownloadWorker {
+    state: WorkerState,
+    descriptor: WorkerStateDescriptor,
+}
+
+impl PeerAddr {
+    pub fn new(peer_addr: SocketAddrV4) -> Self {
+        Self { peer_addr }
+    }
+
+    #[instrument(name = "handshake mode", level = "info", skip_all)]
+    pub async fn handshake(
+        self,
+        info_hash: InfoHash,
+        peer_id: PeerId,
+    ) -> anyhow::Result<PeerDownloaderConnection> {
+        info!("connecting to peer");
+        let mut stream = TcpStream::connect(&self.peer_addr).await?;
+
+        let handshake = PeerHandshake::new(info_hash, peer_id);
+        let mut bytes = handshake.into_bytes();
+
+        info!("sending handshake to peer");
+        stream.write_all(&bytes).await?;
+
+        info!("waiting for peer handshake");
+        stream.read_exact(&mut bytes).await?;
+
+        let handshake = PeerHandshake::from_bytes(bytes);
+        info!("peer handshake received");
+        debug!(peer_handshake_reply = ?handshake);
+
+        Ok(PeerDownloaderConnection {
+            stream,
+            peer_id: handshake.peer_id,
+            peer_addr: self.peer_addr,
+        })
+    }
+}
+
+impl PeerDownloadWorker {
+    const COMMAND_BUFFER_SIZE: usize = 5;
+
+    pub async fn init_from(
+        PeerDownloaderConnection {
+            stream,
+            peer_id,
+            peer_addr,
+            ..
+        }: PeerDownloaderConnection,
+        alerts_tx: mpsc::Sender<PeerAlerts>,
+    ) -> anyhow::Result<PeerDownloadWorker> {
+        let mut peer_stream = codec::upgrade_stream(stream);
+
+        let msg = match peer_stream.next().await {
+            Some(msg_res) => msg_res?,
+            None => {
+                warn!("peer closed connection before handshake");
+                anyhow::bail!("peer closed connection before handshake");
+            }
+        };
+
+        type PM = PeerMessage;
+        let bitfield = match msg {
+            PM::Bitfield(bitfield) => bitfield,
+            _ => {
+                warn!("first message sent by peer was not a bitfield");
+                anyhow::bail!("first message sent by peer not bitfield {:?}", msg);
+            }
+        };
+
+        let (commands_tx, commands_rx) = mpsc::channel(Self::COMMAND_BUFFER_SIZE);
+
+        info!("sending init peer alert to engine");
+        alerts_tx
+            .send(PeerAlerts::InitPeer {
+                peer_addr,
+                bitfield,
+                commands_tx,
+            })
+            .await?;
+        let descriptor =
+            WorkerStateDescriptor::new(peer_stream, peer_addr, peer_id, alerts_tx, commands_rx);
+
+        Ok(Self {
+            descriptor,
+            state: WorkerState::Idle,
+        })
+    }
+
+    pub async fn start_peer_event_loop(&mut self) -> anyhow::Result<()> {
+        loop {
+            self.state.transition(&mut self.descriptor).await?;
+        }
+    }
+}

--- a/src/peers/mod.rs
+++ b/src/peers/mod.rs
@@ -1,4 +1,9 @@
+pub mod download_worker;
+
 mod comms;
+mod descriptor;
+mod progress;
+mod worker_fsm;
 
 pub use comms::*;
 

--- a/src/peers/mod.rs
+++ b/src/peers/mod.rs
@@ -1,3 +1,8 @@
 mod comms;
 
 pub use comms::*;
+
+pub type PieceIndex = usize;
+pub type PieceLength = u32;
+type BlockLength = u32;
+type BlockOffset = u32;

--- a/src/peers/mod.rs
+++ b/src/peers/mod.rs
@@ -1,0 +1,3 @@
+mod comms;
+
+pub use comms::*;

--- a/src/peers/progress.rs
+++ b/src/peers/progress.rs
@@ -1,0 +1,97 @@
+use super::{BlockLength, BlockOffset, PieceLength};
+use crate::prelude::*;
+use std::cmp::min;
+
+#[derive(Debug, Clone)]
+pub(super) struct PieceDownloadProgress {
+    piece_length: PieceLength,
+    request_pending: BlockOffset,
+    downloaded: BlockOffset,
+    pending_blocks: u32,
+}
+
+impl PieceDownloadProgress {
+    const MAX_BLOCK_SIZE: u32 = 1 << 14;
+    const MAX_PENDING_BLOCKS: u32 = 5;
+
+    pub fn new(piece_length: u32) -> Self {
+        Self {
+            piece_length,
+            request_pending: 0,
+            downloaded: 0,
+            pending_blocks: 0,
+        }
+    }
+
+    pub fn next_block_info(&mut self) -> Option<(BlockOffset, BlockLength)> {
+        if self.request_pending == self.piece_length || self.reached_max_pending() {
+            trace!("request blocks pipeline filled");
+            return None;
+        }
+
+        let nbytes_to_end = self.piece_length - self.request_pending;
+        debug_assert!(self.request_pending < self.piece_length);
+
+        let length = min(nbytes_to_end, Self::MAX_BLOCK_SIZE);
+        let out = Some((self.request_pending, length));
+
+        trace!("increment pending blocks");
+        self.pending_blocks += 1;
+        trace!(
+            "move forward request pending offset by next_block_len={}",
+            length
+        );
+        self.request_pending += length;
+        out
+    }
+
+    pub fn update_downloaded(
+        &mut self,
+        block_begin: BlockOffset,
+        length: BlockLength,
+    ) -> anyhow::Result<()> {
+        if block_begin != self.downloaded {
+            warn!(
+                last_downloaded_block = self.downloaded,
+                incoming_block = block_begin,
+                "blocks given out of order by peer"
+            );
+            anyhow::bail!("blocks downloaded out of order. last downloaded offset: {}, incoming block offset: {}", self.downloaded, block_begin)
+        }
+
+        self.downloaded += length;
+        self.pending_blocks -= 1;
+        trace!(
+            downloaded_end_offset = self.downloaded,
+            num_pending_blocks = self.pending_blocks,
+            "update download progress",
+        );
+        Ok(())
+    }
+
+    pub fn reset_progress(&mut self) {
+        debug!(
+            "reset download progress to {last_requested_block_end}",
+            last_requested_block_end = self.request_pending
+        );
+        self.request_pending = self.downloaded;
+        self.pending_blocks = 0;
+    }
+
+    pub fn is_done(&self) -> bool {
+        trace!(
+            "checking if block done {last_downloaded_block_end} {piece_end}",
+            last_downloaded_block_end = self.downloaded,
+            piece_end = self.piece_length
+        );
+        self.downloaded == self.piece_length
+    }
+
+    fn reached_max_pending(&self) -> bool {
+        trace!(
+            "check if reached max pending {num_pending}",
+            num_pending = self.pending_blocks
+        );
+        self.pending_blocks >= Self::MAX_PENDING_BLOCKS
+    }
+}

--- a/src/peers/worker_fsm.rs
+++ b/src/peers/worker_fsm.rs
@@ -1,0 +1,234 @@
+use crate::metainfo::files::FileHash;
+use crate::peer_protocol::codec::PeerMessage;
+use crate::prelude::*;
+use futures::SinkExt;
+use sha1_smol::Sha1;
+use tokio_stream::StreamExt;
+
+use super::descriptor::WorkerStateDescriptor;
+use super::progress::PieceDownloadProgress;
+use super::{PeerAlerts, PeerCommands, PieceIndex, PieceRequestInfo};
+
+#[derive(Debug, Clone)]
+pub enum WorkerState {
+    WaitingforPiece {
+        index: PieceIndex,
+        download_progress: PieceDownloadProgress,
+        hash: FileHash,
+        piece: Vec<u8>,
+    },
+    Idle,
+}
+
+impl WorkerState {
+    pub async fn transition(
+        &mut self,
+        descriptor: &mut WorkerStateDescriptor,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::WaitingforPiece {
+                index,
+                download_progress,
+                hash,
+                piece: piece_vec,
+            } => {
+                let WorkerStateDescriptor {
+                    alerts_tx,
+                    peer_is_choked,
+                    we_are_interested,
+                    peer_stream,
+                    commands_rx,
+                    ..
+                } = descriptor;
+                let span = info_span!("waiting for piece", index);
+                let _gaurd = span.enter();
+
+                if download_progress.is_done() {
+                    info!("piece download complete");
+
+                    let piece_hash = Sha1::from(&piece_vec).digest().bytes();
+                    if piece_hash != *hash {
+                        warn!("downloaded piece hash check failed");
+                        //TODO: what should happen if hash fails?.
+                    } else {
+                        info!("piece hash check succeeded.");
+                    }
+
+                    info!("send piece done");
+                    alerts_tx
+                        .send(PeerAlerts::DonePiece {
+                            piece_index: *index,
+                            piece: std::mem::take(piece_vec),
+                        })
+                        .await?;
+
+                    info!("set peer state idle");
+                    *self = WorkerState::Idle;
+                    return Ok(());
+                }
+
+                if !*we_are_interested {
+                    *we_are_interested = true;
+
+                    info!("sending unchoke");
+                    peer_stream.send(PeerMessage::Unchoke).await?;
+                    info!("sending interested");
+                    peer_stream.send(PeerMessage::Interested).await?;
+                }
+
+                if !*peer_is_choked {
+                    while let Some((begin, length)) = download_progress.next_block_info() {
+                        let request = PeerMessage::Request {
+                            index: *index as u32,
+                            begin,
+                            length,
+                        };
+
+                        info!("sending request to peer {:?}", request);
+                        peer_stream.send(request).await?;
+                    }
+                }
+
+                tokio::select! {
+                    // handle peer messages, abstracting this out to a function is kinda hard.
+                    msg = peer_stream.next() => {
+                        let msg = match msg {
+                            Some(msg) => msg?,
+                            None => {
+                                warn!("peer closed connection before piece could be downloaded");
+                                anyhow::bail!("peer closed connection before piece could be downloaded");
+                            }
+                        };
+
+                        Self::handle_peer_message(msg, *index, descriptor, piece_vec, download_progress).await?;
+                    }
+
+                    // handle commands sent by the engine
+                    Some(command) = commands_rx.recv() => {
+                        Self::handle_command(command, descriptor).await?;
+                    }
+
+                    else => {
+                        // commands channel closed and peer connection was closed
+                        info!("engine and peer shut down, shutting down worker");
+                        anyhow::bail!("shutting down.");
+                    }
+                }
+            }
+
+            Self::Idle => {
+                let WorkerStateDescriptor {
+                    download_queue,
+                    commands_rx,
+                    ..
+                } = descriptor;
+
+                if let Some(PieceRequestInfo {
+                    index,
+                    length,
+                    hash,
+                }) = download_queue.pop_front()
+                {
+                    info!("change peer state to waiting for piece {}", index);
+                    *self = Self::WaitingforPiece {
+                        index,
+                        download_progress: PieceDownloadProgress::new(length),
+                        hash,
+                        piece: Vec::new(),
+                    };
+                    return Ok(());
+                }
+
+                info!("queue empty awaiting next command");
+                match commands_rx.recv().await {
+                    Some(command) => Self::handle_command(command, descriptor).await?,
+                    None => {
+                        anyhow::bail!("commands channel closed while Peer was idle, shutting down")
+                    }
+                };
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_command(
+        command: PeerCommands,
+        WorkerStateDescriptor {
+            peer_stream,
+            we_are_interested,
+            download_queue,
+            ..
+        }: &mut WorkerStateDescriptor,
+    ) -> anyhow::Result<()> {
+        type PC = PeerCommands;
+
+        match command {
+            PC::NotInterested => {
+                info!("sending NotInterested to peer");
+                peer_stream.send(PeerMessage::NotInterested).await?;
+                *we_are_interested = false;
+            }
+            PC::Shutdown => {
+                info!("received shutdown signal, shutting down");
+                anyhow::bail!("received shutdown signal");
+            }
+            PC::DownloadPiece(req_info) => {
+                info!(
+                    "received DownloadPiece, appending piece to download queue {index}",
+                    index = req_info.index
+                );
+                download_queue.push_back(req_info);
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_peer_message(
+        msg: PeerMessage,
+        curr_piece_index: usize,
+        WorkerStateDescriptor { peer_is_choked, .. }: &mut WorkerStateDescriptor,
+        piece: &mut Vec<u8>,
+        download_progress: &mut PieceDownloadProgress,
+    ) -> anyhow::Result<()> {
+        type PM = PeerMessage;
+        match msg {
+            PM::Choke => {
+                info!("peer choked");
+                *peer_is_choked = true;
+                download_progress.reset_progress();
+            }
+            PM::Unchoke => {
+                info!("peer unchoked");
+                *peer_is_choked = false;
+            }
+
+            PM::Piece {
+                index: recv_index,
+                begin,
+                piece: block,
+            } => {
+                let block_span = debug_span!("handle block mesg", begin, index = recv_index);
+                let _gaurd = block_span.enter();
+
+                info!("received block");
+                assert!(recv_index == curr_piece_index as u32);
+
+                debug!(block_length = block.len());
+
+                download_progress.update_downloaded(begin, block.len() as u32)?;
+
+                trace!("appending block onto piece");
+                piece.extend(block);
+                debug!(new_piece_length = piece.len());
+            }
+
+            PM::Have(_)
+            | PM::Cancel { .. }
+            | PM::Bitfield(_)
+            | PM::NotInterested
+            | PM::Interested
+            | PM::Request { .. } => unimplemented!(),
+        }
+        Ok(())
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,5 @@
+#[allow(unused)]
+pub use tracing::{
+    debug, debug_span, error, error_span, info, info_span, instrument, trace, trace_span, warn,
+    warn_span,
+};


### PR DESCRIPTION
implement the piece downloading mechanism, message passing channels used to coordinate between an engine task which issues commands, and several peer tasks, which listen to these commands and operate an internal state machine to manage the peer connection to request blocks, which is added to the piece until it is finished and sent back to the engine. the piece then is just dropped inside the engine loop after checking if the hash matches, it is not written to disk, that's probably up next apart from building the engine itself.

Also added tracing to manage logging, most of the peers module is logged, some places in the codebase where logging remains to be added, like the torrent file parser and tracker announcing code.